### PR TITLE
minor fixes

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,7 +1,7 @@
 jwt_secret: secret
 email:
   from_address: auth@ecadlabs.com
-  driver: debug,
+  driver: debug
   config:
     address: smtp.gmail.com:587
     user: auth@ecadlabs.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
 
   envoy:
-    image: envoyproxy/envoy-alpine
+    image: envoyproxy/envoy-alpine:v1.6.0
     volumes:
       - ./envoy/:/etc/envoy
     command: /usr/local/bin/envoy -c /etc/envoy/envoy_dev.yaml


### PR DESCRIPTION
fix typo in sample config and pin Envoy image to v1.6.0

It's not clear why the latest build of the Envoy Alpine image doesn't support the `use_websocket` config field. But pinning it to v1.6.0 resolves the error.