### PR TITLE
WIP: Use HashiCorp Valut for JWT secrets

### DIFF
--- a/docker-compose-vault.yml
+++ b/docker-compose-vault.yml
@@ -1,0 +1,85 @@
+version: '3'
+services:
+
+  envoy:
+    image: envoyproxy/envoy-alpine:v1.6.0
+    volumes:
+      - ./envoy/:/etc/envoy
+    command: /usr/local/bin/envoy -c /etc/envoy/envoy_dev.yaml
+    ports:
+      - "8000:10000"
+      - "9901:9901"
+
+  db:
+    image: "postgres:alpine"
+    environment:
+      - POSTGRES_USER=auth
+      - POSTGRES_PASSWORD=auth
+      - POSTGRES_DB=auth
+
+  auth:
+    build:
+      context: .
+    depends_on:
+      - db
+      - vault
+    environment:
+      - AUTH_ADMIN_EMAIL=admin@admin
+      - AUTH_ADMIN_PASSWORD=admin
+      - AUTH_ADMIN_ROLES=admin
+    entrypoint: /app/auth
+    command:
+      - -db
+      - "postgres://auth:auth@db/auth?connect_timeout=10&sslmode=disable"
+      - -base
+      - "http://localhost:8000/api/v1"
+      - -bootstrap
+      - -namespace
+      - com.ecadlabs.auth
+      - -c
+      - /app/config.yaml
+      - -r
+      - /app/rbac.yaml
+    volumes:
+      - ./config.example.yaml:/app/config.yaml
+
+  apidocs:
+    build:
+      context: apidocs/
+    depends_on:
+      - envoy
+    command: /bin/bash -c "nginx -g 'daemon off;'"
+
+  webapp:
+    build:
+      dockerfile: Dockerfile.dev
+      context: webapp/
+    volumes:
+      - ./webapp/:/app
+      - node_modules_volume:/app/node_modules
+    depends_on:
+      - envoy
+      - auth
+
+  vault:
+    image: vault
+    ports:
+      - 8200:8200
+    command: vault server -dev
+    environment:
+      - VAULT_DEV_ROOT_TOKEN_ID=7D8PoomSmJE7y1rp6yrUvTuY
+      - VAULT_ADDR=http://127.0.0.1:8200
+      - VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200
+
+  vault_webui:
+    image: djenriquez/vault-ui
+    ports:
+      - 8300:8000
+    depends_on:
+      - vault
+    environment:
+      - VAULT_AUTH_DEFAULT=TOKEN
+      - VAULT_URL_DEFAULT=http://vault:8200
+
+volumes:
+  node_modules_volume:


### PR DESCRIPTION
Added `docker-compose-vault.yml` with a vault dev server instance.

To run: `docker-compose -f docker-compose-vault.yml up`

To test the Vault server, open another terminal and run:

```
$ export VAULT_DEV_ROOT_TOKEN_ID=7D8PoomSmJE7y1rp6yrUvTuY
$ vault login token=$VAULT_DEV_ROOT_TOKEN_ID
$ vault status -address="http://127.0.0.1:8200"
```

To see the web ui, go to http://127.0.0.1:8300 and provide the token to login.