### PR TITLE
Add personal role and add example permissions to example rbac. Improve logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,84 @@
 # ECAD Labs auth daemon
+
+`auth` is an authentication and authorization daemon that issues JWT tokens.
+
+It's features include;
+
+* Authentication of user credentials for JWT tokens
+* User management API to create/invite/modify/delete users
+* User Roles that allow assignment of permissions to users 
+* Multi-tenant allowing "teams" of users. Suitable for supporting multiple
+    tenant customers, each of which have users as members in their tenant
+* User creation life-cycle using invitation tokens via email
+* User password reset functionality.
+* Role Based Access Control (RBAC) based on collections (roles) of permission
+    properties.
+
+The project also includes a set of Angular components for managing
+users/tenants/roles that can be used as is, or forked and used in other
+projects. 
+
+# Roles 
+
+Roles are collections of permission properties. A user can have multiple roles
+assigned to her. When a user logs in, the auth daemon will return all
+permission properties that are assigned to the user via the users roles. These
+roles are included in the JWT payload. 
+
+## Permission Properties
+
+Permission properties are simply strings that are consumed by other services.
+
+Each property has a consumer that will enforce some sort of behaviour based on
+the presence or absence of permission properties. It's up to the service
+operator to define their own permission properties, and in turn, enforce rules
+based on the presence or absence of properties.
+
+Permission properties are structured as follows:
+
+`<namespace>`.`<resource_name>`.`<action_verb>`
+
+The auth daemon is itself a consumer of permission properties, but specifically
+for properties that applies to resources that auth controls. These are
+`users`, `tenants` and `service_accounts`, all of which are namespaced under
+the string `com.ecadlabs.`
+
+Other systems that will consume JWT tokens will see permission properties that
+they have no interest in.
+
+## Defining new permission properties
+
+If your using the `auth` daemon, then you will likely want to define
+permissions that apply to your systems domain. To illustrate the definition of
+a new permission set, we will imagine a service named `pinger`. It's job is to
+send pings, and record the sending of pings. 
+
+As an example, we will use a namespace based on the domain name `example.net`.
+This protects us from the possibility of different system using `ping` as a
+resource name.
+
+Our permission properties will be:
+
+`net.example.ping.read`: Allows caller to view all ping records
+`net.example.net.create`: Allows caller to send a ping
+
+We add these definitions to our `auth` daemon via the `rbac.yaml` definition
+file. The auth daemon has no intelligence around how these permissions will be
+used. In your `pinger` service, you will decode and validate the JWT token, and
+within the token. When your `pinger` service receives a request to list
+`pings`, your service should assert the presence of the `net.example.ping.read`
+permission property. If it is not present, your service should reject the
+request with a HTTP code such as `403 - Forbidden`. If your service does find
+the appropriate permission property, then it can service the call accordingly.
+
+# Service Accounts and API Keys
+
+Auth supports "Service Accounts" which are a special type of account designed
+for "Machine to Machine" integrations. An admin can create a service account,
+and generate an API key/token which can then be used to interact with the
+other services that validate the JWT tokens. 
+
+Additionally, a service account can be configured to use an "Allow List" of IP
+CIDR ranges. If the calling parties IP address falls within an Allow List CIDR
+range, the caller will be issued a JWT token.
+

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ It's features include;
 * User Roles that allow assignment of permissions to users 
 * Multi-tenant allowing "teams" of users. Suitable for supporting multiple
     tenant customers, each of which have users as members in their tenant
+* Roles are assigned to users membership in a tenant, allowing a user to have
+    a different set of permissions depending on the tenant they are a member
+    of
 * User creation life-cycle using invitation tokens via email
 * User password reset functionality.
 * Role Based Access Control (RBAC) based on collections (roles) of permission

--- a/rbac.yaml
+++ b/rbac.yaml
@@ -1,27 +1,45 @@
+# this example rbac file allows the operator to define roles and permission
+# strings.
+#
+# roles are simply collections of permissions.
+#
+# permission strings that are assigned to a user via a role are included in the
+# users jwt token. the list of permissions can be inspected by downstream
+# services. when implementing permission checks in a service, it is recommended
+# to namespace your permission strings, and codify them in this file. for
+# example `net.example.service.full_control` can be used. the namespace is
+# arbitrary, but followings ones own domain name reduces chances of collision.
+#
+# the namespace `com.ecadlabs` defined herein are consumed by authd itself for
+# the purpose of permissions. the example `net.example.service.full_control` is
+# not consumed by authd, but might be consumed by a downstream jwt consumer.
+# what the logic that the jwt consumer enforces based on the presence or
+# absence of a particular permission property is outside authd's scope of
+# concern. 
 permissions:
-  com.ecadlabs.users.write: Allows user to create new users
-  com.ecadlabs.users.read: Allows user to view users
-  com.ecadlabs.users.read_self: Allows user to view their own user resource record
-  com.ecadlabs.users.write_self: Allows user to edit their own user resource record
-  com.ecadlabs.users.full_control: Allows user to manage all accounts
-  com.ecadlabs.tenants.full_control: Allows user to manage all tenants
-  com.ecadlabs.tenants.write_owned: Allows user to write to owned tenants
-  com.ecadlabs.tenants.read_owned: Allows user to read owned tenants
-  com.ecadlabs.users.read_logs: Allows user to access logs
-  com.ecadlabs.users.delegate:noc: Assign `noc' role
-  com.ecadlabs.users.delegate:admin: Assign `admin' role
-  com.ecadlabs.users.delegate:owner: Assign `owner' role
-  com.ecadlabs.users.delegate:ops: Assign `ops' role
+  com.ecadlabs.users.write: Allow user to create new users
+  com.ecadlabs.users.read: Allow user to view users
+  com.ecadlabs.users.read_self: Allow user to view their own user resource record
+  com.ecadlabs.users.write_self: Allow user to edit their own user resource record
+  com.ecadlabs.users.full_control: Allow user to manage all accounts
+  com.ecadlabs.tenants.full_control: Allow user to manage all tenants
+  com.ecadlabs.tenants.write_owned: Allow user to write to owned tenants
+  com.ecadlabs.tenants.read_owned: Allow user to read owned tenants
+  com.ecadlabs.users.read_logs: Allow user to access logs
+  # The 'delegate' permission allows the user to assign said permission
+  # to another user. 
+  com.ecadlabs.users.delegate:noc: Allow assignment of 'noc' to other users
+  com.ecadlabs.users.delegate:admin: Allow assignment of 'admin' to other users
+  com.ecadlabs.users.delegate:owner: Allow assignment of 'owner' to other users
+  com.ecadlabs.users.delegate:ops: Allow assignment of 'ops' to other users
   com.ecadlabs.users.delegate:com.ecadlabs.auth.default_personal_role: Assign `Default' role
-  com.ecadlabs.service_accounts.full_control: Allows user to manage service accounts
-  # The org permsissions are speculative/future looking permissions included
-  # here to provoke analysis/critical evaluation
-  com.ecadlabs.org.read_self: Allows user to view the organizations to which they are assigned
-  com.ecadlabs.org.write_self: Allows user to view the organizations to which they are assigned
-  com.ecadlabs.org.billing.read_self: Allows user to view the organizations billing details
-  com.ecadlabs.org.billing.write_self: Allows user to view & edit the organizations billing details
-  net.example.service.full_control: Allows user to use all features of this example service
-  net.example.service.read: Allows user to read resources of this example service
+  com.ecadlabs.service_accounts.full_control: Allow user to manage service accounts
+  com.ecadlabs.org.read_self: Allow user to view the organizations to which they are assigned
+  com.ecadlabs.org.write_self: Allow user to view the organizations to which they are assigned
+  com.ecadlabs.org.billing.read_self: Allow user to view the organizations billing details
+  com.ecadlabs.org.billing.write_self: Allow user to view & edit the organizations billing details
+  net.example.service.full_control: Allow user to use all features of this example service
+  net.example.service.read: Allow user to read resources of this example service
 
 roles:
   default_personal_role:

--- a/rbac.yaml
+++ b/rbac.yaml
@@ -12,6 +12,7 @@ permissions:
   com.ecadlabs.users.delegate:admin: Assign `admin' role
   com.ecadlabs.users.delegate:owner: Assign `owner' role
   com.ecadlabs.users.delegate:ops: Assign `ops' role
+  com.ecadlabs.users.delegate:com.ecadlabs.auth.default_personal_role: Assign `Default' role
   com.ecadlabs.service_accounts.full_control: Allows user to manage service accounts
   # The org permsissions are speculative/future looking permissions included
   # here to provoke analysis/critical evaluation
@@ -19,24 +20,27 @@ permissions:
   com.ecadlabs.org.write_self: Allows user to view the organizations to which they are assigned
   com.ecadlabs.org.billing.read_self: Allows user to view the organizations billing details
   com.ecadlabs.org.billing.write_self: Allows user to view & edit the organizations billing details
-  it.r255.cloudwatch.full_control: Allows user full control of cloudwatch features
-  it.r255.edge.full_control: Allows user full control of edge network visualization features
-  it.r255.grt.full_control: Allows user to use all GRT features, including creating jobs, archiving jobs, etc.
+  net.example.service.full_control: Allows user to use all features of this example service
+  net.example.service.read: Allows user to read resources of this example service
 
 roles:
+  default_personal_role:
+    default: true
+    description: Default Personal Role
+    permissions:
+      - com.ecadlabs.users.read_self
+      - com.ecadlabs.users.write_self
   admin:
     description: A super user that has all access
     permissions:
       - com.ecadlabs.users.full_control
       - com.ecadlabs.service_accounts.full_control
       - com.ecadlabs.tenants.full_control
-      - it.r255.cloudwatch.full_control
-      - it.r255.edge.full_control
-      - it.r255.grt.full_control
       - com.ecadlabs.users.delegate:noc
       - com.ecadlabs.users.delegate:admin
       - com.ecadlabs.users.delegate:ops
       - com.ecadlabs.users.delegate:owner
+      - net.example.service.full_control
   owner:
     description: Tenant owner
     permissions:
@@ -52,12 +56,10 @@ roles:
     permissions:
       - com.ecadlabs.users.read_self
       - com.ecadlabs.users.write_self
-      - it.r255.cloudwatch.full_control
-      - it.r255.edge.full_control
-      - it.r255.grt.full_control
+      - net.example.service.full_control
   ops:
     description: Operations Staff
     permissions:
       - com.ecadlabs.users.read_self
       - com.ecadlabs.users.write_self
-      - it.r255.grt.full_control
+      - net.example.service.read

--- a/rbac/file.go
+++ b/rbac/file.go
@@ -66,7 +66,7 @@ func LoadYAML(name string) (*StaticRBAC, error) {
 	}
 
 	if defaultRoleCount != 1 {
-		return nil, fmt.Errorf("YAML RBAC: Exactly one default role must be defined")
+		return nil, fmt.Errorf("YAML RBAC: Only One default role must be defined, got %d", defaultRoleCount)
 	}
 
 	res := StaticRBAC{


### PR DESCRIPTION
Add personal role and add example permissions

* Add README.md
* Add a new `default_personal_role` role to the rbac.yaml example. One single default role is
required to operate. The `default_personal_role` allows for log in to a
personal tenant, and is useful as an intermediary state for a user
before they are added to a tenant, or if they have been removed from a
tenant.
* Created an example permission service called `net.example.service` to
illustrate how an operator should add new permissions that are consumed
by downstream services.
* Log the number of default rbac roles found when exiting